### PR TITLE
fix: remove browserstack

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,11 +107,6 @@
 			<h2>Supporters</h2>
 
 			<section>
-				<a href="http://browserstack.com/"><img src="./images/browserstack.png" /></a>
-				<p>Free access to browserstack makes it possible to test on multiple platforms, browsers and devices.</p>
-			</section>
-
-			<section>
 				<a href="https://greenkeeper.io/"><img src="./images/greenkeeper.jpg" /></a>
 				<p>Thanks to greenkeeper.io for helping keeping our dependencies up to date.</p>
 			</section>


### PR DESCRIPTION
I removed browserstack as a sponsor, the did nothing for us so far and stopped comunicating with us. I have NO idea why... :cry: 